### PR TITLE
MDI is not initiated by git submodules update

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/levrik/mdi-react",
   "scripts": {
     "clean": "rm -rf build && rm -rf publish/*.js",
-    "build": "git submodule update && npm run clean && mkdir build && node scripts/generate.js && babel build --out-dir publish"
+    "build": "git submodule update --init && npm run clean && mkdir build && node scripts/generate.js && babel build --out-dir publish"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",


### PR DESCRIPTION
According to the git-scm docu [submodule update](https://git-scm.com/docs/git-submodule#git-submodule-update) alone does not setup the required submodules, so I added the `--init` option to the build script in package.json