### PR TITLE
using currentColor as the default instead of #000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This page only documents changes to the library itself, **not** the icons. Please refer to the [mdi history](https://materialdesignicons.com/history) for that.
 
+## Unreleased [![Material Design Icons version](https://img.shields.io/badge/mdi-v2.4.85-blue.svg?style=flat-square)](https://materialdesignicons.com)
+
+### Breaking changes
+
+- [#33](https://github.com/levrik/mdi-react/pull/33) Changed default color of icons to the current text color (`currentColor`).
+
 ## 3.4.0 [![Material Design Icons version](https://img.shields.io/badge/mdi-v2.4.85-blue.svg?style=flat-square)](https://materialdesignicons.com)
 
 _No changes_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,6 @@ _No changes_
 ### New features
 
 - [`d5aac53`](https://github.com/levrik/mdi-react/commit/d5aac537dfcf800a1cdbc24975b4efcdb7766981) Added prop `size`. Default is `24px`.
-- [`544b865`](https://github.com/levrik/mdi-react/commit/544b865a886fd87233e8fe4e0201832bd39286db) Added prop `color`. Default is `currentColor`.
+- [`544b865`](https://github.com/levrik/mdi-react/commit/544b865a886fd87233e8fe4e0201832bd39286db) Added prop `color`. Default is `#000`.
 - [`a86ab93`](https://github.com/levrik/mdi-react/commit/a86ab93cb18456662b70767828f31730419392ea) [#12](https://github.com/levrik/mdi-react/pull/12) Added TypeScript typings
 - [`a80a306`](https://github.com/levrik/mdi-react/commit/a80a306c701d47541b6a8efff3e2dc114204189b) [#15](https://github.com/levrik/mdi-react/pull/15) Added ES module build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,6 @@ _No changes_
 ### New features
 
 - [`d5aac53`](https://github.com/levrik/mdi-react/commit/d5aac537dfcf800a1cdbc24975b4efcdb7766981) Added prop `size`. Default is `24px`.
-- [`544b865`](https://github.com/levrik/mdi-react/commit/544b865a886fd87233e8fe4e0201832bd39286db) Added prop `color`. Default is `#000`.
+- [`544b865`](https://github.com/levrik/mdi-react/commit/544b865a886fd87233e8fe4e0201832bd39286db) Added prop `color`. Default is `currentColor`.
 - [`a86ab93`](https://github.com/levrik/mdi-react/commit/a86ab93cb18456662b70767828f31730419392ea) [#12](https://github.com/levrik/mdi-react/pull/12) Added TypeScript typings
 - [`a80a306`](https://github.com/levrik/mdi-react/commit/a80a306c701d47541b6a8efff3e2dc114204189b) [#15](https://github.com/levrik/mdi-react/pull/15) Added ES module build

--- a/README-preact.md
+++ b/README-preact.md
@@ -30,7 +30,7 @@ import { AlertIcon, AlertCircleIcon } from 'mdi-preact';
 const MyComponent = () => {
   return (
     <div>
-      {/* The default color is #000 */}
+      {/* The default color is the current text color (currentColor) */}
       <AlertIcon color="#fff" />
       {/* The default size is 24 */}
       <AlertCircleIcon class="some-class" size={16} />

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import { AlertIcon, AlertCircleIcon } from 'mdi-react';
 const MyComponent = () => {
   return (
     <div>
-      {/* The default color is #000 */}
+      {/* The default color is currentColor */}
       <AlertIcon color="#fff" />
       {/* The default size is 24 */}
       <AlertCircleIcon className="some-class" size={16} />

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import { AlertIcon, AlertCircleIcon } from 'mdi-react';
 const MyComponent = () => {
   return (
     <div>
-      {/* The default color is currentColor */}
+      {/* The default color is the current text color (currentColor) */}
       <AlertIcon color="#fff" />
       {/* The default size is 24 */}
       <AlertCircleIcon className="some-class" size={16} />

--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ You can also add default styling via the `mdi-icon` class.
 
 ```css
 .mdi-icon {
-  /* Set this to have the color match the current text color */
-  fill: currentColor;
   /* Set this to have the icon size match the current font size */
   width: 1em;
   height: 1em;

--- a/scripts/generate-preact.js
+++ b/scripts/generate-preact.js
@@ -2,7 +2,7 @@ const generate = require('./generate');
 
 generate('preact', component => `import { h } from 'preact';
 
-const ${component.name} = ({ color = '#000', size = 24, children, ...props }) => {
+const ${component.name} = ({ color = 'currentColor', size = 24, children, ...props }) => {
   const className = 'mdi-icon ' + (props.class || props.className || '');
 
   return (

--- a/scripts/generate-react.js
+++ b/scripts/generate-react.js
@@ -2,7 +2,7 @@ const generate = require('./generate');
 
 generate('react', component => `import React from 'react';
 
-const ${component.name} = ({ color = '#000', size = 24, children, ...props }) => {
+const ${component.name} = ({ color = 'currentColor', size = 24, children, ...props }) => {
   const className = 'mdi-icon ' + (props.className || '');
 
   return (


### PR DESCRIPTION
Changing the default fill color to currentColor instead of #000. Which will make the icons default to the text color unless a color prop is passed.

Issue: https://github.com/levrik/mdi-react/issues/32