### PR TITLE
Use React.memo is available

### DIFF
--- a/scripts/generate-react.js
+++ b/scripts/generate-react.js
@@ -12,7 +12,7 @@ const ${component.name} = ({ color = 'currentColor', size = 24, children, ...pro
   );
 };
 
-export default ${component.name};
+export default React.memo ? React.memo(${component.name}) : ${component.name}
 `, component => `import { MdiReactIconComponentType } from './dist/typings';
 
 declare const ${component.name}: MdiReactIconComponentType;

--- a/scripts/generate-react.js
+++ b/scripts/generate-react.js
@@ -12,7 +12,7 @@ const ${component.name} = ({ color = 'currentColor', size = 24, children, ...pro
   );
 };
 
-export default React.memo ? React.memo(${component.name}) : ${component.name}
+export default React.memo ? React.memo(${component.name}) : ${component.name};
 `, component => `import { MdiReactIconComponentType } from './dist/typings';
 
 declare const ${component.name}: MdiReactIconComponentType;


### PR DESCRIPTION
This PR attempts to use `React.memo` if it is avaliable.

I previously attempted implementing `React.memo` (if it isn't avaliable), but this would just increase the bundle size for all users, and as such this feature will only be avaliable for projects which use newer (16.6>=) versions of React.