### PR TITLE
Re-export all icons from the index.js module.

### DIFF
--- a/publish-preact/package.json
+++ b/publish-preact/package.json
@@ -2,6 +2,7 @@
   "name": "mdi-preact",
   "version": "5.3.0",
   "description": "Material Design Icons for Preact",
+  "main": "index.js",
   "keywords": [
     "mdi",
     "preact",

--- a/publish-react/package.json
+++ b/publish-react/package.json
@@ -2,6 +2,7 @@
   "name": "mdi-react",
   "version": "5.3.0",
   "description": "Material Design Icons for React",
+  "main": "index.js",
   "keywords": [
     "mdi",
     "react",

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -124,6 +124,9 @@ async function generate(target, jsCb, tsCb, tsAllCb) {
   mkdirp(publishPath);
   const distPath = path.resolve(publishPath, 'dist');
   mkdirp(distPath);
+  const indexFilePath = path.resolve(basePath, 'publish-' + target, 'index.js');
+
+  const indexFileStream = fs.createWriteStream(indexFilePath, {flags:'a'});
 
   console.log('Collecting components...');
   const components = collectComponents(svgFilesPath);
@@ -159,6 +162,9 @@ async function generate(target, jsCb, tsCb, tsAllCb) {
 
     const definitionContent = tsCb(component);
     fs.writeFileSync(path.join(publishPath, component.defFileName), definitionContent);
+    indexFileStream.write(
+      `export {default as ${component.name}} from './${component.name}';\n`
+    )
   }
 
   console.log('Generating typings...');


### PR DESCRIPTION
Creates a `index.js`-file which exports all icons from it. Additionally, specifies `index.js` as `main` in `package.json`.