### PR TITLE
Support module modes `node16` and `nodenext` in TypeScript

### DIFF
--- a/scripts/generate-preact.js
+++ b/scripts/generate-preact.js
@@ -16,7 +16,7 @@ export default ${component.name};
 `, component => `import { MdiReactIconComponentType } from './dist/typings';
 
 declare const ${component.name}: MdiReactIconComponentType;
-export default ${component.name};
+export = ${component.name};
 `, () => `import { FunctionalComponent } from 'preact';
 
 // TODO(pcorpet): Extends SVGProps when it exists in Preact.

--- a/scripts/generate-react.js
+++ b/scripts/generate-react.js
@@ -16,7 +16,7 @@ export default React.memo ? React.memo(${component.name}) : ${component.name};
 `, component => `import { MdiReactIconComponentType } from './dist/typings';
 
 declare const ${component.name}: MdiReactIconComponentType;
-export default ${component.name};
+export = ${component.name};
 `, () => `import { ComponentType, SVGProps } from 'react';
 
 type AllSVGProps = SVGProps<SVGSVGElement>


### PR DESCRIPTION
Fixes #102